### PR TITLE
Fix no "device.model" error because Homebridge isn't connecting

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ NutAccessory.prototype = {
 			.setCharacteristic(Characteristic.Name, this.name)
 			.setCharacteristic(Characteristic.SerialNumber, this.accVars["ups.serial"] || 'No Serial#')
 			.setCharacteristic(Characteristic.FirmwareRevision, this.accVars["ups.firmware"] || 'No Data')
-			.setCharacteristic(Characteristic.Model, this.accVars["device.model"].trim() || this.accVars["ups.productid"] || 'No Model#');
+			.setCharacteristic(Characteristic.Model, this.accVars["device.model"] === undefined ? false : this.accVars["device.model"].trim() || this.accVars["ups.productid"] || 'No Model#');
 		services.push(this.serviceInfo);
 
 		this.serviceBatt = new Service.BatteryService();


### PR DESCRIPTION
I have same issue by #10 .
But my friend is success.

JS crash because JS get "device.model" is undefined can not to "trim()".
And i fixed it.

<img width="1680" alt="螢幕快照 2019-07-21 下午5 32 52 (c)" src="https://user-images.githubusercontent.com/2195746/61589632-60b45b00-abdf-11e9-89b5-50ba851866be.png">
In image: Left side is my friend. Right side is mine.